### PR TITLE
Changes the secure Uri to point to www.gravatar as opposed to secure.…

### DIFF
--- a/src/GravatarHelper.Common/GravatarHelper.cs
+++ b/src/GravatarHelper.Common/GravatarHelper.cs
@@ -74,7 +74,7 @@ namespace GravatarHelper.Common
         /// <summary>
         /// Gravatar HTTPS url.
         /// </summary>
-        private const string GravatarSecureUrl = "https://secure.gravatar.com";
+        private const string GravatarSecureUrl = "https://www.gravatar.com";
 
         /// <summary>
         /// Gravatar image path.


### PR DESCRIPTION
…gravatar

This is to fix issue #4 - I've tested this on my site and it works as expected.